### PR TITLE
Moving copies of HBGshop and .nro's to location of functioning .nro

### DIFF
--- a/HBG
+++ b/HBG
@@ -20,5 +20,9 @@
     (HGB Discord) socket.json
     (HGB Discord) tinfoil.nro
   (HGB Discord) reboot_to_payload.nro
+  (HGB Discord) hgbShop_forwarder_dark_v3.nsp
+  (HGB Discord) hbmenu.nro
+  (HGB Discord) tinfoil.nro
+  (HGB Discord) mercury.nro
 (HGB Discord) hgbShop_forwarder_dark_v3.nsp
 (HGB Discord) hbmenu.nro


### PR DESCRIPTION
Original HBG setup only showed Reboot To Payload .nro

Saved a copy of all .nro files to the location of Reboot To Payload .nro
Saved a copy of hbgshop file from root to location of Reboot To Payload.nro

injected with fusee-primary.bin

open album with 
   R- album
   A- hbrmenu, no .nro's on sdmc:/
   L- mercury

//tried
looking through mercury's file browser to install hbgshop, no good